### PR TITLE
設定処理を共通化してテストを拡充

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,12 @@
 - Chromium 系ブラウザ向けの拡張機能です。
 - 対象は e-Gov 法令ページで、全角括弧 `（...）` をハイライトします。
 - 主な実装箇所:
+  - `src/settings.js`: 既定値、storage キー、設定値の正規化と後方互換処理
   - `src/content.js`: ページ上のハイライト処理本体
   - `src/background.js`: バッジ更新、ショートカット、タブ同期
   - `src/options.js` / `src/options.css`: 表示設定 UI
   - `tests/*.test.js`: `node:test` ベースの単体テスト
+    - `tests/settings.test.js`: 共有設定と各実行コンテキストの読み込み配線
 
 ## 作業ルール
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ e-Gov 法令ページ内の全角括弧 `（...）` をハイライト表示す�
 
 ## ファイル構成
 
+- `src/settings.js`: 既定値、storage キー、設定値の正規化と後方互換処理
 - `src/background.js`: ショートカット処理、バッジ更新、タブ/ウィンドウイベント監視
 - `src/content.js`: ハイライト適用、DOM 変化追従（`MutationObserver`）
 - `src/popup.html` + `src/options.js` + `src/options.css`: 表示設定 UI

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,12 @@
 {
   "manifest_version": 3,
   "name": "e-Gov Decorator",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Decorate brackets on e-Gov laws pages",
   "content_scripts": [
     {
       "matches": ["https://elaws.e-gov.go.jp/*", "https://laws.e-gov.go.jp/*"],
-      "js": ["src/content.js"],
+      "js": ["src/settings.js", "src/content.js"],
       "css": ["src/style.css"]
     }
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "egov-decorator",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "egov-decorator",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "husky": "^9.1.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egov-decorator",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "scripts": {
     "check": "biome check . --error-on-warnings",

--- a/src/background.js
+++ b/src/background.js
@@ -1,10 +1,23 @@
+if (!globalThis.EgovDecoratorSettings) {
+  importScripts("settings.js");
+}
+
+const {
+  DEFAULT_HIGHLIGHT_LEVEL,
+  OFF_HIGHLIGHT_LEVEL,
+  MAX_HIGHLIGHT_LEVEL,
+  STORAGE_KEYS,
+  isDecoratorEnabled,
+  normalizeHighlightLevel,
+  getStoredHighlightLevel,
+  isHighlightEnabled,
+  createHighlightLevelStorage,
+} = globalThis.EgovDecoratorSettings;
+
 const TARGET_URL_PATTERN = /^https:\/\/(?:elaws|laws)\.e-gov\.go\.jp\/law\//;
 const EGOV_DOMAIN_URL_PATTERN = /^https:\/\/(?:elaws|laws)\.e-gov\.go\.jp\//;
-const DECORATOR_ENABLED_KEY = "decoratorEnabled";
-const HIGHLIGHT_LEVEL_KEY = "highlightLevel";
-const DEFAULT_HIGHLIGHT_LEVEL = 0;
-const OFF_HIGHLIGHT_LEVEL = 4;
-const MAX_HIGHLIGHT_LEVEL = OFF_HIGHLIGHT_LEVEL;
+const DECORATOR_ENABLED_KEY = STORAGE_KEYS.decoratorEnabled;
+const HIGHLIGHT_LEVEL_KEY = STORAGE_KEYS.highlightLevel;
 const BADGE_TEXT_OFF = "OFF";
 const BADGE_BG_ON = "#d93025";
 const BADGE_BG_OFF = "#188038";
@@ -23,34 +36,6 @@ function isTargetUrl(url) {
 
 function isEgovDomainUrl(url) {
   return typeof url === "string" && EGOV_DOMAIN_URL_PATTERN.test(url);
-}
-
-function isDecoratorEnabled(value) {
-  return value !== false;
-}
-
-function normalizeHighlightLevel(value) {
-  const level = Number(value);
-  if (!Number.isInteger(level)) return null;
-  if (level < DEFAULT_HIGHLIGHT_LEVEL || level > MAX_HIGHLIGHT_LEVEL) {
-    return null;
-  }
-  return level;
-}
-
-function getStoredHighlightLevel(result) {
-  const items = result && typeof result === "object" ? result : {};
-  const normalizedLevel = normalizeHighlightLevel(items[HIGHLIGHT_LEVEL_KEY]);
-  if (normalizedLevel != null) {
-    return normalizedLevel;
-  }
-  return isDecoratorEnabled(items[DECORATOR_ENABLED_KEY])
-    ? DEFAULT_HIGHLIGHT_LEVEL
-    : OFF_HIGHLIGHT_LEVEL;
-}
-
-function isHighlightEnabled(level) {
-  return level !== OFF_HIGHLIGHT_LEVEL;
 }
 
 function getBadgeText(level) {
@@ -212,11 +197,7 @@ function withHighlightLevel(callback) {
 
 function saveHighlightLevel(highlightLevel, callback) {
   chrome.storage.local.set(
-    {
-      [HIGHLIGHT_LEVEL_KEY]: highlightLevel,
-      // Keep legacy key in sync for backward compatibility.
-      [DECORATOR_ENABLED_KEY]: isHighlightEnabled(highlightLevel),
-    },
+    createHighlightLevelStorage(highlightLevel),
     callback,
   );
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,3 +1,17 @@
+const {
+  DEFAULT_BG_COLOR,
+  DEFAULT_TEXT_COLOR,
+  DEFAULT_HIGHLIGHT_LEVEL,
+  OFF_HIGHLIGHT_LEVEL,
+  STORAGE_KEYS,
+  getColorOrDefault,
+  getStoredColor,
+  isDecoratorEnabled,
+  normalizeHighlightLevel,
+  getStoredHighlightLevel,
+  isHighlightEnabled,
+} = globalThis.EgovDecoratorSettings;
+
 function createHighlightedElement(text) {
   const span = document.createElement("span");
   span.className = "egov-highlight";
@@ -7,13 +21,8 @@ function createHighlightedElement(text) {
 
 const BRACKET_PATTERN = /[（）]/;
 const TARGET_URL_PATTERN = /^https:\/\/(?:elaws|laws)\.e-gov\.go\.jp\/law\//;
-const DEFAULT_BG_COLOR = "#e6e6e6";
-const DEFAULT_TEXT_COLOR = "#ffffff";
-const DECORATOR_ENABLED_KEY = "decoratorEnabled";
-const HIGHLIGHT_LEVEL_KEY = "highlightLevel";
-const DEFAULT_HIGHLIGHT_LEVEL = 0;
-const OFF_HIGHLIGHT_LEVEL = 4;
-const MAX_HIGHLIGHT_LEVEL = OFF_HIGHLIGHT_LEVEL;
+const DECORATOR_ENABLED_KEY = STORAGE_KEYS.decoratorEnabled;
+const HIGHLIGHT_LEVEL_KEY = STORAGE_KEYS.highlightLevel;
 const CROSS_NODE_CONTAINER_TAGS = new Set([
   "p",
   "div",
@@ -38,53 +47,16 @@ const UNSAFE_CROSS_NODE_TAGS = new Set([
   "colgroup",
   "col",
 ]);
-const HIGHLIGHT_BG_COLOR_KEY = "highlightBgColor";
-const HIGHLIGHT_TEXT_COLOR_KEY = "highlightTextColor";
+const HIGHLIGHT_BG_COLOR_KEY = STORAGE_KEYS.highlightBgColor;
+const HIGHLIGHT_TEXT_COLOR_KEY = STORAGE_KEYS.highlightTextColor;
 let currentHighlightBgColor = DEFAULT_BG_COLOR;
 let currentHighlightTextColor = DEFAULT_TEXT_COLOR;
 let isCurrentUrlTarget = false;
 let lastKnownUrl = "";
 let observerRoot = null;
 
-function getColorOrDefault(value, defaultColor) {
-  return value || defaultColor;
-}
-
-function getStoredColor(result, key, defaultColor) {
-  const items = result && typeof result === "object" ? result : {};
-  return getColorOrDefault(items[key], defaultColor);
-}
-
-function isDecoratorEnabled(value) {
-  return value !== false;
-}
-
 function isTargetUrl(url) {
   return typeof url === "string" && TARGET_URL_PATTERN.test(url);
-}
-
-function normalizeHighlightLevel(value) {
-  const level = Number(value);
-  if (!Number.isInteger(level)) return null;
-  if (level < DEFAULT_HIGHLIGHT_LEVEL || level > MAX_HIGHLIGHT_LEVEL) {
-    return null;
-  }
-  return level;
-}
-
-function getStoredHighlightLevel(result) {
-  const items = result && typeof result === "object" ? result : {};
-  const normalizedLevel = normalizeHighlightLevel(items[HIGHLIGHT_LEVEL_KEY]);
-  if (normalizedLevel != null) {
-    return normalizedLevel;
-  }
-  return isDecoratorEnabled(items[DECORATOR_ENABLED_KEY])
-    ? DEFAULT_HIGHLIGHT_LEVEL
-    : OFF_HIGHLIGHT_LEVEL;
-}
-
-function isHighlightEnabled(level) {
-  return level !== OFF_HIGHLIGHT_LEVEL;
 }
 
 function getMinHighlightDepth(level) {

--- a/src/options.js
+++ b/src/options.js
@@ -1,20 +1,21 @@
-const DEFAULT_BG_COLOR = "#e6e6e6";
-const DEFAULT_TEXT_COLOR = "#ffffff";
-const DECORATOR_ENABLED_KEY = "decoratorEnabled";
-const HIGHLIGHT_LEVEL_KEY = "highlightLevel";
-const HIGHLIGHT_BG_COLOR_KEY = "highlightBgColor";
-const HIGHLIGHT_TEXT_COLOR_KEY = "highlightTextColor";
-const DEFAULT_HIGHLIGHT_LEVEL = 0;
-const OFF_HIGHLIGHT_LEVEL = 4;
-const MAX_HIGHLIGHT_LEVEL = OFF_HIGHLIGHT_LEVEL;
+const {
+  DEFAULT_BG_COLOR,
+  DEFAULT_TEXT_COLOR,
+  DEFAULT_HIGHLIGHT_LEVEL,
+  STORAGE_KEYS,
+  getStoredColor,
+  getStoredHighlightLevel,
+  createHighlightLevelStorage,
+} = globalThis.EgovDecoratorSettings;
+
+const DECORATOR_ENABLED_KEY = STORAGE_KEYS.decoratorEnabled;
+const HIGHLIGHT_LEVEL_KEY = STORAGE_KEYS.highlightLevel;
+const HIGHLIGHT_BG_COLOR_KEY = STORAGE_KEYS.highlightBgColor;
+const HIGHLIGHT_TEXT_COLOR_KEY = STORAGE_KEYS.highlightTextColor;
 const STATUS_CLEAR_DELAY_MS = 1500;
 
 function byId(id) {
   return document.getElementById(id);
-}
-
-function getColorOrDefault(value, defaultColor) {
-  return value || defaultColor;
 }
 
 function showStatus(message) {
@@ -54,48 +55,12 @@ function loadSettings() {
   );
 }
 
-function getStoredColor(result, key, defaultColor) {
-  const items = result && typeof result === "object" ? result : {};
-  return getColorOrDefault(items[key], defaultColor);
-}
-
-function isDecoratorEnabled(value) {
-  return value !== false;
-}
-
-function normalizeHighlightLevel(value) {
-  const level = Number(value);
-  if (!Number.isInteger(level)) return null;
-  if (level < DEFAULT_HIGHLIGHT_LEVEL || level > MAX_HIGHLIGHT_LEVEL) {
-    return null;
-  }
-  return level;
-}
-
-function getStoredHighlightLevel(result) {
-  const items = result && typeof result === "object" ? result : {};
-  const normalizedLevel = normalizeHighlightLevel(items[HIGHLIGHT_LEVEL_KEY]);
-  if (normalizedLevel != null) {
-    return normalizedLevel;
-  }
-  return isDecoratorEnabled(items[DECORATOR_ENABLED_KEY])
-    ? DEFAULT_HIGHLIGHT_LEVEL
-    : OFF_HIGHLIGHT_LEVEL;
-}
-
-function isHighlightEnabled(level) {
-  return level !== OFF_HIGHLIGHT_LEVEL;
-}
-
 function saveSettings(bgColor, textColor, highlightLevel) {
-  const normalizedLevel =
-    normalizeHighlightLevel(highlightLevel) ?? DEFAULT_HIGHLIGHT_LEVEL;
   chrome.storage.local.set(
     {
       [HIGHLIGHT_BG_COLOR_KEY]: bgColor,
       [HIGHLIGHT_TEXT_COLOR_KEY]: textColor,
-      [HIGHLIGHT_LEVEL_KEY]: normalizedLevel,
-      [DECORATOR_ENABLED_KEY]: isHighlightEnabled(normalizedLevel),
+      ...createHighlightLevelStorage(highlightLevel),
     },
     () => {
       showStatus("保存しました");

--- a/src/popup.html
+++ b/src/popup.html
@@ -63,6 +63,7 @@
       </div>
     </main>
 
+    <script src="settings.js"></script>
     <script src="options.js"></script>
   </body>
 </html>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,86 @@
+(() => {
+  const DEFAULT_BG_COLOR = "#e6e6e6";
+  const DEFAULT_TEXT_COLOR = "#ffffff";
+  const DEFAULT_HIGHLIGHT_LEVEL = 0;
+  const OFF_HIGHLIGHT_LEVEL = 4;
+  const MAX_HIGHLIGHT_LEVEL = OFF_HIGHLIGHT_LEVEL;
+  const STORAGE_KEYS = Object.freeze({
+    decoratorEnabled: "decoratorEnabled",
+    highlightLevel: "highlightLevel",
+    highlightBgColor: "highlightBgColor",
+    highlightTextColor: "highlightTextColor",
+  });
+
+  function toSettingsRecord(value) {
+    return value && typeof value === "object" ? value : {};
+  }
+
+  function getColorOrDefault(value, defaultColor) {
+    return value || defaultColor;
+  }
+
+  function getStoredColor(result, key, defaultColor) {
+    return getColorOrDefault(toSettingsRecord(result)[key], defaultColor);
+  }
+
+  function isDecoratorEnabled(value) {
+    return value !== false;
+  }
+
+  function normalizeHighlightLevel(value) {
+    const level = Number(value);
+    if (!Number.isInteger(level)) return null;
+    if (level < DEFAULT_HIGHLIGHT_LEVEL || level > MAX_HIGHLIGHT_LEVEL) {
+      return null;
+    }
+    return level;
+  }
+
+  function getLegacyHighlightLevel(decoratorEnabled) {
+    return isDecoratorEnabled(decoratorEnabled)
+      ? DEFAULT_HIGHLIGHT_LEVEL
+      : OFF_HIGHLIGHT_LEVEL;
+  }
+
+  function getStoredHighlightLevel(result) {
+    const items = toSettingsRecord(result);
+    const normalizedLevel = normalizeHighlightLevel(
+      items[STORAGE_KEYS.highlightLevel],
+    );
+    return (
+      normalizedLevel ??
+      getLegacyHighlightLevel(items[STORAGE_KEYS.decoratorEnabled])
+    );
+  }
+
+  function isHighlightEnabled(level) {
+    return level !== OFF_HIGHLIGHT_LEVEL;
+  }
+
+  function createHighlightLevelStorage(value) {
+    const highlightLevel =
+      normalizeHighlightLevel(value) ?? DEFAULT_HIGHLIGHT_LEVEL;
+    return {
+      [STORAGE_KEYS.highlightLevel]: highlightLevel,
+      // Keep legacy key in sync for backward compatibility.
+      [STORAGE_KEYS.decoratorEnabled]: isHighlightEnabled(highlightLevel),
+    };
+  }
+
+  globalThis.EgovDecoratorSettings = Object.freeze({
+    DEFAULT_BG_COLOR,
+    DEFAULT_TEXT_COLOR,
+    DEFAULT_HIGHLIGHT_LEVEL,
+    OFF_HIGHLIGHT_LEVEL,
+    MAX_HIGHLIGHT_LEVEL,
+    STORAGE_KEYS,
+    getColorOrDefault,
+    getStoredColor,
+    isDecoratorEnabled,
+    normalizeHighlightLevel,
+    getLegacyHighlightLevel,
+    getStoredHighlightLevel,
+    isHighlightEnabled,
+    createHighlightLevelStorage,
+  });
+})();

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@
   - `tests/background.test.js`
   - `tests/content.test.js`
   - `tests/options.test.js`
+  - `tests/settings.test.js`
 
 ## Coverage Map
 
@@ -107,7 +108,7 @@
   - 既存 highlight を外して再適用すること
   - 開始直前に無効化された場合に observer 開始後処理を中断すること
 
-現在の単体テスト件数は 94 件です（`npm test`）。
+現在の単体テスト件数は 117 件です（`npm test`）。
 
 ### `options.test.js`
 
@@ -124,6 +125,24 @@
 - `DOMContentLoaded` 後イベント:
   - submit で現在入力値保存
   - reset でデフォルトレベル/色保存
+
+### `settings.test.js`
+
+以下を網羅しています。
+
+- 共有設定定数:
+  - 既定色、ハイライトレベル、storage キーの値と不変性
+- ハイライトレベル正規化:
+  - 0〜4 の整数と数値文字列
+  - 範囲外、小数、非数値の拒否
+- 新旧 storage キー互換:
+  - `highlightLevel` の優先
+  - 不正値から `decoratorEnabled` へのフォールバック
+  - 保存時の `highlightLevel` / `decoratorEnabled` 同期
+- 色設定:
+  - 保存値と既定値の選択
+- 読み込み配線:
+  - content script、popup、background からの `settings.js` 読み込み
 
 ## Residual Gaps
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,7 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
-const { loadScript } = require("./helpers/load-script");
+const { loadScript, loadScripts } = require("./helpers/load-script");
+
+const SCRIPT_PATHS = [
+  path.resolve(__dirname, "..", "src", "settings.js"),
+  path.resolve(__dirname, "..", "src", "background.js"),
+];
 
 function createEvent() {
   let listener = null;
@@ -115,6 +120,9 @@ function createBackgroundHarness(options = {}) {
     chrome,
     Map,
     console: options.console ?? console,
+  };
+  context.importScripts = (scriptPath) => {
+    loadScript(path.resolve(__dirname, "..", "src", scriptPath), context);
   };
   loadScript(path.resolve(__dirname, "..", "src", "background.js"), context);
 
@@ -518,7 +526,7 @@ test("setBadgeForTab: 閉じたタブの Promise reject(No tab with id) を無�
   };
 
   const context = { chrome, Map, console };
-  loadScript(path.resolve(__dirname, "..", "src", "background.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
 
   const unhandledRejections = await captureUnhandledRejections(async () => {
     context.setBadgeForTab(99, "https://laws.e-gov.go.jp/law/a", 0);
@@ -595,7 +603,7 @@ test("setBadgeForTab: No tab with id 以外の Promise reject は console.error 
     },
   };
 
-  loadScript(path.resolve(__dirname, "..", "src", "background.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
 
   context.setBadgeForTab(77, "https://laws.e-gov.go.jp/law/a", 0);
   await new Promise((resolve) => setImmediate(resolve));
@@ -676,7 +684,7 @@ test("setBadgeForTab: 非同期 reject 確定前でも同一状態の再試行�
     },
   };
 
-  loadScript(path.resolve(__dirname, "..", "src", "background.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
 
   context.setBadgeForTab(78, "https://laws.e-gov.go.jp/law/a", 0);
   context.setBadgeForTab(78, "https://laws.e-gov.go.jp/law/a", 0);
@@ -729,7 +737,7 @@ test("setBadgeForTab: 同期 throw(No tab with id) 時にキャッシュを残�
   };
 
   const context = { chrome, Map, console };
-  loadScript(path.resolve(__dirname, "..", "src", "background.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
 
   context.setBadgeForTab(55, "https://example.com/", 0);
   context.setBadgeForTab(55, "https://example.com/", 0);
@@ -743,9 +751,10 @@ test("setBadgeForTab: 同期 throw(No tab with id) 時にキャッシュを残�
 test("getStoredHighlightLevel: 範囲外の highlightLevel は既定値へフォールバック", () => {
   const { context } = createBackgroundHarness();
 
-  assert.equal(context.getStoredHighlightLevel({ highlightLevel: 99 }), 0);
+  const { getStoredHighlightLevel } = context.EgovDecoratorSettings;
+  assert.equal(getStoredHighlightLevel({ highlightLevel: 99 }), 0);
   assert.equal(
-    context.getStoredHighlightLevel({
+    getStoredHighlightLevel({
       highlightLevel: -1,
       decoratorEnabled: false,
     }),

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -1,7 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
-const { loadScript } = require("./helpers/load-script");
+const { loadScripts } = require("./helpers/load-script");
+
+const SCRIPT_PATHS = [
+  path.resolve(__dirname, "..", "src", "settings.js"),
+  path.resolve(__dirname, "..", "src", "content.js"),
+];
 
 class FakeTextNode {
   constructor(value) {
@@ -138,7 +143,7 @@ function createContentContext() {
     console,
   };
 
-  loadScript(path.resolve(__dirname, "..", "src", "content.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
   return { context, FakeElement, FakeTextNode };
 }
 
@@ -284,7 +289,7 @@ function createLifecycleContentContext({
     }
   };
 
-  loadScript(path.resolve(__dirname, "..", "src", "content.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
   return {
     context,
     fakeDocument,
@@ -548,7 +553,12 @@ test("collectDecoratableTextNodes: script/style と既存 highlight 内を除外
 
 test("getStoredHighlightLevel: legacy decoratorEnabled=false は OFF", () => {
   const { context } = createContentContext();
-  assert.equal(context.getStoredHighlightLevel({ decoratorEnabled: false }), 4);
+  assert.equal(
+    context.EgovDecoratorSettings.getStoredHighlightLevel({
+      decoratorEnabled: false,
+    }),
+    4,
+  );
 });
 
 test("removeHighlightInRoot: 同一親の複数spanでも normalize は1回だけ", () => {
@@ -601,9 +611,10 @@ test("removeHighlightInRoot: 親が異なる場合は親ごとに normalize す�
 
 test("isDecoratorEnabled: false のみ無効、それ以外は有効", () => {
   const { context } = createContentContext();
-  assert.equal(context.isDecoratorEnabled(false), false);
-  assert.equal(context.isDecoratorEnabled(undefined), true);
-  assert.equal(context.isDecoratorEnabled(true), true);
+  const { isDecoratorEnabled } = context.EgovDecoratorSettings;
+  assert.equal(isDecoratorEnabled(false), false);
+  assert.equal(isDecoratorEnabled(undefined), true);
+  assert.equal(isDecoratorEnabled(true), true);
 });
 
 test("setHighlightLevel: 非対象URLでは DOM を変更しない", () => {
@@ -663,9 +674,10 @@ test("body 待機中に対象外 URL へ変わったら observer 開始を取り
 
 test("normalizeHighlightLevel: 範囲外は null", () => {
   const { context } = createContentContext();
+  const { normalizeHighlightLevel } = context.EgovDecoratorSettings;
 
-  assert.equal(context.normalizeHighlightLevel(-1), null);
-  assert.equal(context.normalizeHighlightLevel(99), null);
+  assert.equal(normalizeHighlightLevel(-1), null);
+  assert.equal(normalizeHighlightLevel(99), null);
 });
 
 test("applyColorChanges: 色変更時だけ CSS 変数を更新する", () => {

--- a/tests/helpers/load-script.js
+++ b/tests/helpers/load-script.js
@@ -3,9 +3,18 @@ const vm = require("node:vm");
 
 function loadScript(filePath, context) {
   const source = fs.readFileSync(filePath, "utf8");
-  vm.createContext(context);
+  if (!vm.isContext(context)) {
+    vm.createContext(context);
+  }
   vm.runInContext(source, context, { filename: filePath });
   return context;
 }
 
-module.exports = { loadScript };
+function loadScripts(filePaths, context) {
+  filePaths.forEach((filePath) => {
+    loadScript(filePath, context);
+  });
+  return context;
+}
+
+module.exports = { loadScript, loadScripts };

--- a/tests/options.test.js
+++ b/tests/options.test.js
@@ -1,7 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const path = require("node:path");
-const { loadScript } = require("./helpers/load-script");
+const { loadScripts } = require("./helpers/load-script");
+
+const SCRIPT_PATHS = [
+  path.resolve(__dirname, "..", "src", "settings.js"),
+  path.resolve(__dirname, "..", "src", "options.js"),
+];
 
 class FakeElement {
   constructor(id) {
@@ -66,7 +71,7 @@ function createOptionsContext({ storedValues = {}, storageGetResult } = {}) {
     console,
   };
 
-  loadScript(path.resolve(__dirname, "..", "src", "options.js"), context);
+  loadScripts(SCRIPT_PATHS, context);
 
   return {
     context,

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -140,8 +140,10 @@ test("読み込み配線: content と popup は settings.js を先に読み込�
     "src/settings.js",
     "src/content.js",
   ]);
-  assert.ok(
-    popup.indexOf('src="settings.js"') < popup.indexOf('src="options.js"'),
-  );
+  const settingsScriptIndex = popup.indexOf('src="settings.js"');
+  const optionsScriptIndex = popup.indexOf('src="options.js"');
+  assert.notEqual(settingsScriptIndex, -1);
+  assert.notEqual(optionsScriptIndex, -1);
+  assert.ok(settingsScriptIndex < optionsScriptIndex);
   assert.match(background, /importScripts\("settings\.js"\)/);
 });

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -1,0 +1,147 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { loadScript } = require("./helpers/load-script");
+
+const SETTINGS_PATH = path.resolve(__dirname, "..", "src", "settings.js");
+
+function createSettingsContext() {
+  return loadScript(SETTINGS_PATH, {});
+}
+
+function normalize(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("設定定数: 既定値と storage キーを一元管理する", () => {
+  const { EgovDecoratorSettings: settings } = createSettingsContext();
+
+  assert.equal(settings.DEFAULT_BG_COLOR, "#e6e6e6");
+  assert.equal(settings.DEFAULT_TEXT_COLOR, "#ffffff");
+  assert.equal(settings.DEFAULT_HIGHLIGHT_LEVEL, 0);
+  assert.equal(settings.OFF_HIGHLIGHT_LEVEL, 4);
+  assert.equal(settings.MAX_HIGHLIGHT_LEVEL, 4);
+  assert.deepEqual(normalize(settings.STORAGE_KEYS), {
+    decoratorEnabled: "decoratorEnabled",
+    highlightLevel: "highlightLevel",
+    highlightBgColor: "highlightBgColor",
+    highlightTextColor: "highlightTextColor",
+  });
+  assert.equal(Object.isFrozen(settings), true);
+  assert.equal(Object.isFrozen(settings.STORAGE_KEYS), true);
+});
+
+test("normalizeHighlightLevel: 0〜4 の整数と数値文字列を受け入れる", async (t) => {
+  const { normalizeHighlightLevel } =
+    createSettingsContext().EgovDecoratorSettings;
+  const cases = [
+    [0, 0],
+    [1, 1],
+    [4, 4],
+    ["0", 0],
+    ["3", 3],
+  ];
+
+  for (const [input, expected] of cases) {
+    await t.test(`${JSON.stringify(input)} -> ${expected}`, () => {
+      assert.equal(normalizeHighlightLevel(input), expected);
+    });
+  }
+});
+
+test("normalizeHighlightLevel: 範囲外・小数・非数値を拒否する", async (t) => {
+  const { normalizeHighlightLevel } =
+    createSettingsContext().EgovDecoratorSettings;
+  const cases = [-1, 5, 1.5, "invalid", undefined];
+
+  for (const input of cases) {
+    await t.test(`${String(input)} -> null`, () => {
+      assert.equal(normalizeHighlightLevel(input), null);
+    });
+  }
+});
+
+test("getStoredHighlightLevel: 有効な新キーを legacy キーより優先する", () => {
+  const { getStoredHighlightLevel } =
+    createSettingsContext().EgovDecoratorSettings;
+
+  assert.equal(
+    getStoredHighlightLevel({ highlightLevel: 2, decoratorEnabled: false }),
+    2,
+  );
+});
+
+test("getStoredHighlightLevel: 新キーが不正なら legacy キーへフォールバックする", () => {
+  const { getStoredHighlightLevel } =
+    createSettingsContext().EgovDecoratorSettings;
+
+  assert.equal(
+    getStoredHighlightLevel({
+      highlightLevel: "invalid",
+      decoratorEnabled: false,
+    }),
+    4,
+  );
+  assert.equal(getStoredHighlightLevel({ highlightLevel: 99 }), 0);
+  assert.equal(getStoredHighlightLevel(null), 0);
+});
+
+test("getLegacyHighlightLevel: false のみ OFF として扱う", () => {
+  const { getLegacyHighlightLevel } =
+    createSettingsContext().EgovDecoratorSettings;
+
+  assert.equal(getLegacyHighlightLevel(false), 4);
+  assert.equal(getLegacyHighlightLevel(true), 0);
+  assert.equal(getLegacyHighlightLevel(undefined), 0);
+  assert.equal(getLegacyHighlightLevel(null), 0);
+});
+
+test("getStoredColor: 保存色を返し、未設定では既定色を返す", () => {
+  const { getStoredColor } = createSettingsContext().EgovDecoratorSettings;
+
+  assert.equal(
+    getStoredColor({ color: "#123456" }, "color", "#ffffff"),
+    "#123456",
+  );
+  assert.equal(getStoredColor({}, "color", "#ffffff"), "#ffffff");
+  assert.equal(getStoredColor(null, "color", "#ffffff"), "#ffffff");
+});
+
+test("createHighlightLevelStorage: 新旧キーを常に整合させる", async (t) => {
+  const { createHighlightLevelStorage } =
+    createSettingsContext().EgovDecoratorSettings;
+  const cases = [
+    [0, { highlightLevel: 0, decoratorEnabled: true }],
+    ["3", { highlightLevel: 3, decoratorEnabled: true }],
+    [4, { highlightLevel: 4, decoratorEnabled: false }],
+    [99, { highlightLevel: 0, decoratorEnabled: true }],
+  ];
+
+  for (const [input, expected] of cases) {
+    await t.test(`${JSON.stringify(input)} の保存値`, () => {
+      assert.deepEqual(normalize(createHighlightLevelStorage(input)), expected);
+    });
+  }
+});
+
+test("読み込み配線: content と popup は settings.js を先に読み込む", () => {
+  const root = path.resolve(__dirname, "..");
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(root, "manifest.json"), "utf8"),
+  );
+  const popup = fs.readFileSync(path.join(root, "src", "popup.html"), "utf8");
+  const background = fs.readFileSync(
+    path.join(root, "src", "background.js"),
+    "utf8",
+  );
+
+  assert.deepEqual(manifest.content_scripts[0].js, [
+    "src/settings.js",
+    "src/content.js",
+  ]);
+  assert.ok(
+    popup.indexOf('src="settings.js"') < popup.indexOf('src="options.js"'),
+  );
+  assert.match(background, /importScripts\("settings\.js"\)/);
+});


### PR DESCRIPTION
設定処理を共通化し、後方互換性を維持しながらテストと関連資料を更新しました。

- 設定定数とstorage互換処理をsrc/settings.jsへ集約
- content script・background・popupの共有設定読み込みを追加
- 設定境界値と読み込み配線のテストを追加して117件へ拡充